### PR TITLE
dcatno_informationModel_en.owl utvidelse for tovegsrelasjoner omtalt i #120

### DIFF
--- a/ontology/dcatno_informationModel_en.owl
+++ b/ontology/dcatno_informationModel_en.owl
@@ -611,6 +611,8 @@ modelldcatno:sequenceNumber rdf:type owl:DatatypeProperty ;
 
 ###  https://data.norge.no/vocabulary/modelldcatno#symmetryLabel
 modelldcatno:symmetryLabel rdf:type owl:DatatypeProperty ;
+                           rdfs:domain modelldcatno:Property ;
+                           rdfs:range rdfs:Literal ;
                            rdfs:label "Egenskapspar-navn"@nb ,
                                       "Symmetry Label"@en .
 

--- a/ontology/dcatno_informationModel_en.owl
+++ b/ontology/dcatno_informationModel_en.owl
@@ -227,7 +227,9 @@ modelldcatno:containsObjectType rdf:type owl:ObjectProperty ;
 modelldcatno:formsSymmetryWith rdf:type owl:ObjectProperty ,
                                         owl:SymmetricProperty ;
                                rdfs:domain modelldcatno:Property ;
-                               rdfs:range modelldcatno:Property .
+                               rdfs:range modelldcatno:Property ;
+                               rdfs:label "Forms symmetry with"@en ,
+                                          "Utgjør symetrisk relasjon med"@nb .
 
 
 ###  https://data.norge.no/vocabulary/modelldcatno#hasDataType
@@ -608,7 +610,9 @@ modelldcatno:sequenceNumber rdf:type owl:DatatypeProperty ;
 
 
 ###  https://data.norge.no/vocabulary/modelldcatno#symmetryLabel
-modelldcatno:symmetryLabel rdf:type owl:DatatypeProperty .
+modelldcatno:symmetryLabel rdf:type owl:DatatypeProperty ;
+                           rdfs:label "Egenskapspar-navn"@nb ,
+                                      "Symmetry Label"@en .
 
 
 ###  https://data.norge.no/vocabulary/modelldcatno#typeDefinitionReference

--- a/ontology/dcatno_informationModel_en.owl
+++ b/ontology/dcatno_informationModel_en.owl
@@ -1,4 +1,5 @@
 @prefix : <https://data.norge.no/vocabulary/modelldcatno/> .
+@prefix ex: <http://example.com/test#> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@@ -220,6 +221,13 @@ modelldcatno:containsObjectType rdf:type owl:ObjectProperty ;
                                 rdfs:range modelldcatno:ObjectType ;
                                 rdfs:label "contains object type"@en ,
                                            "inneholder objekttype"@nb .
+
+
+###  https://data.norge.no/vocabulary/modelldcatno#formsSymmetryWith
+modelldcatno:formsSymmetryWith rdf:type owl:ObjectProperty ,
+                                        owl:SymmetricProperty ;
+                               rdfs:domain modelldcatno:Property ;
+                               rdfs:range modelldcatno:Property .
 
 
 ###  https://data.norge.no/vocabulary/modelldcatno#hasDataType
@@ -597,6 +605,10 @@ modelldcatno:sequenceNumber rdf:type owl:DatatypeProperty ;
                             rdfs:comment "Der man har en modell der elementenes orden er vesentlig, f. eks. slik det jo ofte er i XML"@nb ;
                             rdfs:label "Sekvensnummer"@nb ,
                                        "sequence number"@en .
+
+
+###  https://data.norge.no/vocabulary/modelldcatno#symmetryLabel
+modelldcatno:symmetryLabel rdf:type owl:DatatypeProperty .
 
 
 ###  https://data.norge.no/vocabulary/modelldcatno#typeDefinitionReference
@@ -1114,6 +1126,74 @@ modelldcatno:Specialization rdf:type owl:Class ;
                             rdfs:subClassOf modelldcatno:Property ;
                             rdfs:label "Specialization"@en ,
                                        "Spesialisering"@nb .
+
+
+#################################################################
+#    Individuals
+#################################################################
+
+###  http://example.com/test#A
+ex:A rdf:type owl:NamedIndividual ,
+              modelldcatno:ObjectType ;
+     modelldcatno:hasProperty ex:ab .
+
+
+###  http://example.com/test#B
+ex:B rdf:type owl:NamedIndividual ,
+              modelldcatno:ObjectType ;
+     modelldcatno:hasProperty ex:ba .
+
+
+###  http://example.com/test#C
+ex:C rdf:type owl:NamedIndividual ,
+              modelldcatno:ObjectType ;
+     modelldcatno:hasProperty ex:cd .
+
+
+###  http://example.com/test#D
+ex:D rdf:type owl:NamedIndividual ,
+              modelldcatno:ObjectType ;
+     modelldcatno:hasProperty ex:dc .
+
+
+###  http://example.com/test#ab
+ex:ab rdf:type owl:NamedIndividual ,
+               modelldcatno:Role ;
+      modelldcatno:formsSymmetryWith ex:ba ;
+      modelldcatno:hasObjectType ex:B ;
+      dct:title "B sin rolle" ;
+      xsd:maxOccurs "*"^^xsd:string ;
+      xsd:minOccurs "1"^^xsd:int ;
+      modelldcatno:symmetryLabel "Navn på relasjonen (Kan settes på ab og/eller ba)"@nb .
+
+
+###  http://example.com/test#ba
+ex:ba rdf:type owl:NamedIndividual ,
+               modelldcatno:Role ;
+      modelldcatno:hasObjectType ex:A ;
+      dct:title "A sin rolle" ;
+      xsd:maxOccurs "1"^^xsd:int ;
+      xsd:minOccurs "0"^^xsd:int .
+
+
+###  http://example.com/test#cd
+ex:cd rdf:type owl:NamedIndividual ,
+               modelldcatno:Composition ;
+      modelldcatno:contains ex:D ;
+      modelldcatno:formsSymmetryWith ex:dc ;
+      dct:title "D sin rolle" ;
+      xsd:maxOccurs "*"^^xsd:string ;
+      xsd:minOccurs "1"^^xsd:int ;
+      modelldcatno:symmetryLabel "Relasjonen C D"@nb .
+
+
+###  http://example.com/test#dc
+ex:dc rdf:type owl:NamedIndividual ,
+               modelldcatno:Role ;
+      modelldcatno:hasObjectType ex:C ;
+      dct:title "C sin rolle" ;
+      xsd:maxOccurs "1"^^xsd:int ;
+      xsd:minOccurs "0"^^xsd:int .
 
 
 #################################################################


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12021922/86175899-666f2c00-bb24-11ea-8b25-ff211557d5e2.png)

Disse to eksemplene lar seg modelere ved hjelp av en liten utvidelse, en dataproperty og en objectproperty som beskriver et parvis forhold mellom to eksisterende instanser av modelldcatno:Property klassen, eller subklasser av denne.

Som individuals, er en eksempelgraf som beskriver forholdene over. Denne er bare for illustrasjon og bør ikke tas med i selve standarden.

#120 @ToHelland 