### PR TITLE
Lagt inn lenke til alternativ modellrepresentasjon

### DIFF
--- a/ontology/dcatno_informationModel_en.owl
+++ b/ontology/dcatno_informationModel_en.owl
@@ -404,6 +404,7 @@ dct:modified rdf:type owl:DatatypeProperty ;
 dct:title rdf:type owl:DatatypeProperty ;
           rdfs:domain [ rdf:type owl:Class ;
                         owl:unionOf ( dcat:Resource
+                                      foaf:Document
                                       modelldcatno:Code
                                       modelldcatno:ModelElement
                                       modelldcatno:Property

--- a/ontology/dcatno_informationModel_en.owl
+++ b/ontology/dcatno_informationModel_en.owl
@@ -36,6 +36,14 @@ dct:creator rdf:type owl:ObjectProperty ;
                        "skaper"@nb .
 
 
+###  http://purl.org/dc/terms/hasFormat
+dct:hasFormat rdf:type owl:ObjectProperty ;
+              rdfs:domain modelldcatno:InformationModel ;
+              rdfs:range foaf:Document ;
+              rdfs:label "finnes i format"@en ,
+                         "has format"@en .
+
+
 ###  http://purl.org/dc/terms/hasPart
 dct:hasPart rdf:type owl:ObjectProperty ;
             owl:inverseOf dct:isPartOf ;
@@ -942,6 +950,10 @@ modelldcatno:InformationModel rdf:type owl:Class ;
                                               [ rdf:type owl:Restriction ;
                                                 owl:onProperty dct:creator ;
                                                 owl:someValuesFrom foaf:Agent
+                                              ] ,
+                                              [ rdf:type owl:Restriction ;
+                                                owl:onProperty dct:hasFormat ;
+                                                owl:someValuesFrom foaf:Document
                                               ] ,
                                               [ rdf:type owl:Restriction ;
                                                 owl:onProperty dct:hasPart ;


### PR DESCRIPTION
Lagt inn mulighet for referanse til alternativt format for modellen. En kan da f. eks. vise til et skjema i form av en xsd, og bruke modellelementene til å trekke fram de viktigste konseptene, uten at man må være komplett.