### PR TITLE
Kodeverk light

### DIFF
--- a/ontology/dcatno_informationModel_en.owl
+++ b/ontology/dcatno_informationModel_en.owl
@@ -260,7 +260,8 @@ modelldcatno:containsCode rdf:type owl:ObjectProperty ;
                           rdfs:domain modelldcatno:CodeList ;
                           rdfs:range modelldcatno:Code ;
                           rdfs:label "contains code"@en ,
-                                     "inneholder kode"@nb .
+                                     "inneholder kode"@nb ;
+                          owl:deprecated "true"^^xsd:boolean .
 
 
 ###  https://data.norge.no/vocabulary/modelldcatno#containsModelElement
@@ -1212,8 +1213,9 @@ modelldcatno:Specialization rdf:type owl:Class ;
 ex-code:kode rdf:type owl:NamedIndividual ,
                       modelldcatno:Code ;
              skos:inScheme ex-code:kodeliste ;
+             skos:topConceptOf ex-code:kodeliste ;
              skos:notation "3405"^^xsd:string ;
-             skos:definition "Lillehammer er en by og kommune i Gudbrandsdalen i Innlandet, ved nordenden av Mjøsa."@nb ;
+             skos:note "Lillehammer er en by og kommune i Gudbrandsdalen i Innlandet, ved nordenden av Mjøsa."@nb ;
              skos:prefLabel "Lillehammer"@nb .
 
 

--- a/ontology/dcatno_informationModel_en.owl
+++ b/ontology/dcatno_informationModel_en.owl
@@ -184,55 +184,15 @@ dct:type rdf:type owl:ObjectProperty ;
                     "type eller genre"@nb .
 
 
-###  http://www.w3.org/2004/02/skos/core#broader
-skos:broader rdf:type owl:ObjectProperty ;
-             rdfs:subPropertyOf skos:broaderTransitive ;
-             owl:inverseOf skos:narrower .
-
-
-###  http://www.w3.org/2004/02/skos/core#broaderTransitive
-skos:broaderTransitive rdf:type owl:ObjectProperty ;
-                       rdfs:subPropertyOf skos:semanticRelation ;
-                       owl:inverseOf skos:narrowerTransitive ;
-                       rdf:type owl:TransitiveProperty ;
-                       owl:propertyDisjointWith skos:related .
-
-
-###  http://www.w3.org/2004/02/skos/core#hasTopConcept
-skos:hasTopConcept rdf:type owl:ObjectProperty .
-
-
 ###  http://www.w3.org/2004/02/skos/core#inScheme
 skos:inScheme rdf:type owl:ObjectProperty ;
               rdfs:range skos:ConceptScheme .
 
 
-###  http://www.w3.org/2004/02/skos/core#narrower
-skos:narrower rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf skos:narrowerTransitive .
-
-
-###  http://www.w3.org/2004/02/skos/core#narrowerTransitive
-skos:narrowerTransitive rdf:type owl:ObjectProperty ;
-                        rdfs:subPropertyOf skos:semanticRelation ;
-                        rdf:type owl:TransitiveProperty .
-
-
-###  http://www.w3.org/2004/02/skos/core#related
-skos:related rdf:type owl:ObjectProperty ;
-             rdfs:subPropertyOf skos:semanticRelation ;
-             rdf:type owl:SymmetricProperty .
-
-
-###  http://www.w3.org/2004/02/skos/core#semanticRelation
-skos:semanticRelation rdf:type owl:ObjectProperty ;
-                      rdfs:domain skos:Concept ;
-                      rdfs:range skos:Concept ;
-                      rdfs:label "semantic relation"@en .
-
-
 ###  http://www.w3.org/2004/02/skos/core#topConceptOf
-skos:topConceptOf rdf:type owl:ObjectProperty .
+skos:topConceptOf rdf:type owl:ObjectProperty ;
+                  rdfs:domain skos:Concept ;
+                  rdfs:range skos:ConceptScheme .
 
 
 ###  http://www.w3.org/ns/adms#status
@@ -433,99 +393,16 @@ modelldcatno:references rdf:type owl:ObjectProperty ;
                                    "refererer"@nb .
 
 
-###  https://rdf-vocabulary.ddialliance.org/xkos/after
-xkos:after rdf:type owl:ObjectProperty ;
-           rdfs:subPropertyOf xkos:temporal ;
-           rdf:type owl:TransitiveProperty ;
-           owl:deprecated "true"^^xsd:boolean .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/before
-xkos:before rdf:type owl:ObjectProperty ;
-            rdfs:subPropertyOf xkos:temporal ;
-            rdf:type owl:TransitiveProperty ;
-            owl:deprecated "true"^^xsd:boolean .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/causal
-xkos:causal rdf:type owl:ObjectProperty ;
-            rdfs:subPropertyOf skos:related .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/causedBy
-xkos:causedBy rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf xkos:causal .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/causes
-xkos:causes rdf:type owl:ObjectProperty ;
-            rdfs:subPropertyOf xkos:causal .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/disjoint
-xkos:disjoint rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf skos:related ;
-              owl:deprecated "true"^^xsd:boolean .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/generalizes
-xkos:generalizes rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf skos:narrower ;
-                 owl:inverseOf xkos:specializes .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/hasPart
-xkos:hasPart rdf:type owl:ObjectProperty ;
-             rdfs:subPropertyOf skos:narrower ;
-             owl:inverseOf xkos:isPartOf .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/isPartOf
-xkos:isPartOf rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf skos:broader .
-
-
 ###  https://rdf-vocabulary.ddialliance.org/xkos/next
 xkos:next rdf:type owl:ObjectProperty ;
-          rdfs:subPropertyOf xkos:succeeds ;
-          owl:deprecated "true"^^xsd:boolean .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/precedes
-xkos:precedes rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf xkos:sequential ;
-              rdf:type owl:TransitiveProperty ;
-              owl:deprecated "true"^^xsd:boolean .
+          rdfs:domain skos:Concept ;
+          rdfs:range skos:Concept .
 
 
 ###  https://rdf-vocabulary.ddialliance.org/xkos/previous
 xkos:previous rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf xkos:precedes ;
-              owl:deprecated "true"^^xsd:boolean .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/sequential
-xkos:sequential rdf:type owl:ObjectProperty ;
-                rdfs:subPropertyOf skos:related ;
-                owl:deprecated "true"^^xsd:boolean .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/specializes
-xkos:specializes rdf:type owl:ObjectProperty ;
-                 rdfs:subPropertyOf skos:broader .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/succeeds
-xkos:succeeds rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf xkos:sequential ;
-              rdf:type owl:TransitiveProperty ;
-              owl:deprecated "true"^^xsd:boolean .
-
-
-###  https://rdf-vocabulary.ddialliance.org/xkos/temporal
-xkos:temporal rdf:type owl:ObjectProperty ;
-              rdfs:subPropertyOf xkos:sequential ;
-              owl:deprecated "true"^^xsd:boolean .
+              rdfs:domain skos:Concept ;
+              rdfs:range skos:Concept .
 
 
 #################################################################

--- a/ontology/dcatno_informationModel_en.owl
+++ b/ontology/dcatno_informationModel_en.owl
@@ -43,17 +43,12 @@ skos:hiddenLabel rdf:type owl:AnnotationProperty ;
 
 
 ###  http://www.w3.org/2004/02/skos/core#note
-skos:note rdf:type owl:AnnotationProperty ;
-          rdfs:range skos:Concept ,
-                     modelldcatno:Code ;
-          rdfs:domain modelldcatno:Code .
+skos:note rdf:type owl:AnnotationProperty .
 
 
 ###  http://www.w3.org/2004/02/skos/core#prefLabel
 skos:prefLabel rdf:type owl:AnnotationProperty ;
-               rdfs:subPropertyOf rdfs:label ;
-               rdfs:range skos:Concept ,
-                          modelldcatno:Code .
+               rdfs:subPropertyOf rdfs:label .
 
 
 ###  http://www.w3.org/2004/02/skos/core#scopeNote
@@ -253,15 +248,6 @@ modelldcatno:contains rdf:type owl:ObjectProperty ;
                       rdfs:range modelldcatno:ModelElement ;
                       rdfs:label "contains"@en ,
                                  "inneholder"@nb .
-
-
-###  https://data.norge.no/vocabulary/modelldcatno#containsCode
-modelldcatno:containsCode rdf:type owl:ObjectProperty ;
-                          rdfs:domain modelldcatno:CodeList ;
-                          rdfs:range modelldcatno:Code ;
-                          rdfs:label "contains code"@en ,
-                                     "inneholder kode"@nb ;
-                          owl:deprecated "true"^^xsd:boolean .
 
 
 ###  https://data.norge.no/vocabulary/modelldcatno#containsModelElement
@@ -972,7 +958,22 @@ modelldcatno:Choice rdf:type owl:Class ;
 
 ###  https://data.norge.no/vocabulary/modelldcatno#Code
 modelldcatno:Code rdf:type owl:Class ;
-                  rdfs:subClassOf skos:Concept ,
+                  rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                    owl:onProperty skos:inScheme ;
+                                    owl:someValuesFrom modelldcatno:CodeList
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty skos:topConceptOf ;
+                                    owl:someValuesFrom modelldcatno:CodeList
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty xkos:next ;
+                                    owl:someValuesFrom modelldcatno:Code
+                                  ] ,
+                                  [ rdf:type owl:Restriction ;
+                                    owl:onProperty xkos:previous ;
+                                    owl:someValuesFrom modelldcatno:Code
+                                  ] ,
                                   [ rdf:type owl:Restriction ;
                                     owl:onProperty skos:notation ;
                                     owl:someValuesFrom rdfs:Literal
@@ -993,8 +994,7 @@ modelldcatno:Code rdf:type owl:Class ;
 
 ###  https://data.norge.no/vocabulary/modelldcatno#CodeList
 modelldcatno:CodeList rdf:type owl:Class ;
-                      rdfs:subClassOf skos:ConceptScheme ,
-                                      modelldcatno:ModelElement ,
+                      rdfs:subClassOf modelldcatno:ModelElement ,
                                       [ rdf:type owl:Restriction ;
                                         owl:onProperty modelldcatno:hasProperty ;
                                         owl:qualifiedCardinality "0"^^xsd:nonNegativeInteger ;


### PR DESCRIPTION
Tilpassing av kodelister moderert som skos:Consept. Minimalt med xkos:next og previous som eneste semantiske relasjon.

Det ligger og et eksempel her, siden skos bruker annocation properties, er det kanskje best å vise. Om det skal inn i standarden er jeg derimot usikker på.