### PR TITLE
Alfabetisk rekkeflg. mellom eksklusivt min.. og eksklusivt maks er feil.

### DIFF
--- a/docs/14_EgenskaperEnkeltype.adoc
+++ b/docs/14_EgenskaperEnkeltype.adoc
@@ -30,19 +30,7 @@ Klassen _Enkeltype_ er anbefalt
 |Kravsnivå| Valgfri
 |===
 
-===== Enkeltype: eksklusivt minimum (xsd:minExclusive)	[[Enkeltype-eksklusivtMinimum]]
-
-[cols="30s,70d"]
-|===
-|Engelsk navn |exclusive minimum
-|URI |xsd:minExclusive
-|Range |xsd:decimal
-|Beskrivelse |Spesifiserer den nedre grensene for en numerisk verdi (verdien må være større enn denne verdien).
-|Multiplisitet |0..1
-|Kravsnivå |Valgfri
-|===
-
-===== Enkeltype: eksklusivt maksimum (xsd:maxExclusive)	[[Enkeltype-eksklusivtMaksimum]]
+===== Enkeltype: eksklusivt maksimum (xsd:maxExclusive) [[Enkeltype-eksklusivtMaksimum]]
 
 [cols="30s,70d"]
 |===
@@ -50,6 +38,18 @@ Klassen _Enkeltype_ er anbefalt
 |URI |xsd:maxExclusive
 |Range |xsd:decimal
 |Beskrivelse |Spesifiserer den øvre grensene for en numerisk verdi (verdien må være mindre enn denne verdien)
+|Multiplisitet |0..1
+|Kravsnivå |Valgfri
+|===
+
+===== Enkeltype: eksklusivt minimum (xsd:minExclusive) [[Enkeltype-eksklusivtMinimum]]
+
+[cols="30s,70d"]
+|===
+|Engelsk navn |exclusive minimum
+|URI |xsd:minExclusive
+|Range |xsd:decimal
+|Beskrivelse |Spesifiserer den nedre grensene for en numerisk verdi (verdien må være større enn denne verdien).
 |Multiplisitet |0..1
 |Kravsnivå |Valgfri
 |===


### PR DESCRIPTION
Retter opp alfabetisk rekkefølge mellom min og maks som var feil. 