### PR TITLE
Gjør modelltegning klikkebar.

### DIFF
--- a/docs/6_Modell.adoc
+++ b/docs/6_Modell.adoc
@@ -1,6 +1,7 @@
 = Forenklet modell for ModellDCAT-AP-NO [[Forenklet-modell]]
 
 .Forenklet modell for ModellDCAT-AP-NO.
+[link=images/ModellDCAT-AP-NO-20210323.png]
 image::images/ModellDCAT-AP-NO-20210323.png[]
 
 Last ned modell: link:images/ModellDCAT-AP-NO-20210323.png[png] | link:files/ModellDCAT_AP_NO_20210323.eapx[XMI for EA]


### PR DESCRIPTION
Etter innspill fra Stig endrer jeg asciidoc-kodingen slik at selve modelltegningen også er klikkebar (fungerer på samme måte som å klikke på png-lenken). 