### PR TITLE
Fjernet codeListReference

### DIFF
--- a/ontology/modelldcatno.owl
+++ b/ontology/modelldcatno.owl
@@ -26,9 +26,9 @@
 ###  http://www.w3.org/2000/01/rdf-schema#seeAlso
 rdfs:seeAlso rdfs:label "har referanse"@nb ,
                         "has reference"@en ;
-             rdfs:range rdfs:Literal ;
              rdfs:domain dct:Standard ,
-                         dcat:Resource .
+                         dcat:Resource ,
+                         modelldcatno:CodeList .
 
 
 ###  http://www.w3.org/2002/07/owl#versionInfo
@@ -304,16 +304,6 @@ modelldcatno:belongsToModule rdf:type owl:ObjectProperty ,
                              rdfs:range modelldcatno:Module ;
                              rdfs:label "belongs to module"@en ,
                                         "konseptet tilhører modul"@nb .
-
-
-###  https://data.norge.no/vocabulary/modelldcatno#codeListReference
-modelldcatno:codeListReference rdf:type owl:ObjectProperty ,
-                                        owl:FunctionalProperty ,
-                                        owl:IrreflexiveProperty ;
-                               rdfs:domain modelldcatno:CodeList ;
-                               rdfs:range modelldcatno:CodeList ;
-                               rdfs:label "code list reference"@en ,
-                                          "ekstern kodeliste"@nb .
 
 
 ###  https://data.norge.no/vocabulary/modelldcatno#constrains


### PR DESCRIPTION
rdfs:seeAlso er jo en annotation property. Den kan jo egentlig brukes hvor som helst der man har behov for den. Vi har ellers i standarden satt domain for slike properties, så jeg har gjort det her også. 
Det er egentlig litt feil, da vi egentlig utrykker et snittet mellom klassene som er listet opp. Dette har ingen konsekvenser riktignok siden annocation properties blir ignorert av tjenesten som utleder den logiske modellen i en OWL.