### PR TITLE
chore: use reusable workflows

### DIFF
--- a/.github/workflows/publish-docs-to-github-pages.yml
+++ b/.github/workflows/publish-docs-to-github-pages.yml
@@ -2,7 +2,6 @@ name: Build and publish docs to GitHub pages
 
 permissions:
   contents: write
-  pages: write
 
 on:
   push:
@@ -13,39 +12,17 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
+  build-adocs:
     name: asciidoctor build
-    steps:
-
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/modelldcat-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
-          publish_dir: ./docs
-          destination_dir: ./specification
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
+    with:
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/modelldcat-ap-no.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      publish_branch: gh-pages
+      publish_dir: ./docs
+      destination_dir: ./specification
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docs-to-github-pages.yml
+++ b/.github/workflows/publish-docs-to-github-pages.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build-adocs:
     name: asciidoctor build
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/develop'
     uses: Informasjonsforvaltning/workflows/.github/workflows/specification-github-pages.yaml@main
     with:
       program_html: |

--- a/.github/workflows/publish-docs-v1-to-production.yml
+++ b/.github/workflows/publish-docs-v1-to-production.yml
@@ -12,48 +12,25 @@ on:
   workflow_dispatch:
 
 jobs:
-  adoc_build:
-    runs-on: ubuntu-latest
-    name: asciidoctor build
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: v1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html
-        id: adocbuild
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc"
-
-      - name: Build pdf
-        id: adocbuild_pdf
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor-pdf -D docs -o files/modelldcat-ap-no.pdf -a lang=nb docs/main.adoc"
-        continue-on-error: true
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-rdf
-        with:
-          ontology-type: "specification"
-          ontology: "modelldcat-ap-no"
-          host: "https://fellesdatakatalog.digdir.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            docs/index.html text/html nb
-            docs/files/modelldcat-ap-no.pdf application/pdf nb files/modelldcat-ap-no.pdf
-            docs/files/ModellDCAT-AP-NO_V1_3_20230703.eapx application/octet-stream nb files/ModellDCAT-AP-NO_V1_3_20230703.eapx
-            docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
-            docs/images/ModellDCAT-AP-NO_V1-3_20230703.png image/png nb images/ModellDCAT-AP-NO_V1-3_20230703.png
-            docs/images/Digdir.png image/png nb images/Digdir.png
+  upload-files-to-production:
+    name: Upload specification to static-rdf-server
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -D docs -o index.html -a lang=nb docs/main.adoc
+      program_pdf: |
+        asciidoctor-pdf -D docs -o files/modelldcat-ap-no.pdf -a lang=nb docs/main.adoc
+      program_pdf_continue_on_error: true
+      host: https://fellesdatakatalog.digdir.no
+      ontology: modelldcat-ap-no
+      ontology-type: specification
+      files: |
+        docs/index.html text/html nb
+        docs/files/modelldcat-ap-no.pdf application/pdf nb files/modelldcat-ap-no.pdf
+        docs/files/ModellDCAT-AP-NO_V1_3_20230703.eapx application/octet-stream nb files/ModellDCAT-AP-NO_V1_3_20230703.eapx
+        docs/images/digitaliseringsdirektoratet.png image/png nb images/digitaliseringsdirektoratet.png
+        docs/images/ModellDCAT-AP-NO_V1-3_20230703.png image/png nb images/ModellDCAT-AP-NO_V1-3_20230703.png
+        docs/images/Digdir.png image/png nb images/Digdir.png
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}

--- a/.github/workflows/publish-docs-v1-to-production.yml
+++ b/.github/workflows/publish-docs-v1-to-production.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   upload-files-to-production:
     name: Upload specification to static-rdf-server
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/v1'
     uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
     with:
       ref: v1

--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   upload-files-to-production:
     name: Upload vocabulary to static-rdf-server
+    if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/v1'
     uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
     with:
       ref: v1

--- a/.github/workflows/publish-ontology-to-production.yml
+++ b/.github/workflows/publish-ontology-to-production.yml
@@ -12,45 +12,20 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_uploading_of_file:
+  upload-files-to-production:
     name: Upload vocabulary to static-rdf-server
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          ref: v1
-          submodules: true
-          fetch-depth: 0
-
-      - name: Update submodules to latest main
-        run: |
-          git submodule foreach --recursive git fetch origin
-          git submodule foreach --recursive git checkout origin/main
-
-      - name: Build html en
-        id: adocbuild_html_en
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc"
-
-      - name: Build html nb
-        id: adocbuild_html_nb
-        uses: tonynv/asciidoctor-action@master
-        with:
-          program: "asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc"
-
-      - name: Upload rdf to static-rdf-server
-        uses: Informasjonsforvaltning/upload-files-to-static-rdf-server-action@v3.2.0
-        id: upload-rdf
-        with:
-          ontology-type: "vocabulary"
-          ontology: "modelldcatno"
-          host: "https://data.norge.no"
-          api-key: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}
-          files: |
-            ontology/modelldcatno.ttl text/turtle en
-            ontology/index-nb.html text/html nb
-            ontology/index-en.html text/html en
+    uses: Informasjonsforvaltning/workflows/.github/workflows/specification-upload-files.yaml@main
+    with:
+      ref: v1
+      program_html: |
+        asciidoctor -a data-uri -D ontology -o index-en.html -a lang=en ontology/main-en.adoc
+        asciidoctor -a data-uri -D ontology -o index-nb.html -a lang=nb ontology/main-nb.adoc
+      host: https://data.norge.no
+      ontology: modelldcatno
+      ontology-type: vocabulary
+      files: |
+        ontology/modelldcatno.ttl text/turtle en
+        ontology/index-nb.html text/html nb
+        ontology/index-en.html text/html en
+    secrets:
+      STATIC_RDF_SERVER_API_KEY: ${{ secrets.STATIC_RDF_SERVER_API_KEY }}


### PR DESCRIPTION
# Summary
Migrate the three GitHub Actions workflows to call the centralized Informasjonsforvaltning/workflows reusable workflows. Triggers and published file lists preserved verbatim.

- publish-docs-to-github-pages.yml → specification-github-pages.yaml@main
- publish-docs-v1-to-production.yml → specification-upload-files.yaml@main
- publish-ontology-to-production.yml → specification-upload-files.yaml@main
- Dropped redundant `pages: write` permission and a dead draft-PR guard
- Guard each job so `workflow_dispatch` only publishes from its deploy branch

Closes #467 — reusable workflows pin every action to a commit SHA and replace the abandoned `tonynv/asciidoctor-action` with the upstream image.
Closes #469 — job-level `if:` guard blocks publishing via `workflow_dispatch` from non-deploy branches.